### PR TITLE
chore: code cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,27 +1,31 @@
 {
   "root": true,
-  "ignorePatterns": ["dist", "!**/.*"],
+  "ignorePatterns": ["dist", "node_modules", "!**/.*"],
   "overrides": [
     {
       "files": ["*.svelte"],
-      "globals": {
-        "svelte": true
-      },
       "parser": "svelte-eslint-parser",
-      "parserOptions": {
-        "parser": "@typescript-eslint/parser",
-        "extraFileExtensions": [".svelte"],
-        "sourceType": "module",
-        "project": "tsconfig.json"
-      },
       "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:@typescript-eslint/strict",
         "plugin:svelte/recommended",
+        "plugin:import/recommended",
+        "plugin:import/typescript",
         "plugin:prettier/recommended",
         "plugin:svelte/prettier"
       ],
+      "parserOptions": {
+        "parser": "@typescript-eslint/parser",
+        "extraFileExtensions": [".svelte"],
+        "sourceType": "module",
+        "project": "tsconfig.svelte.json",
+        "ecmaVersion": "latest"
+      },
+      "env": {
+        "browser": true
+      },
       "rules": {
         "@typescript-eslint/no-unused-vars": [
           "error",
@@ -31,26 +35,23 @@
           }
         ]
       },
-      "env": {
-        "browser": true,
-        "es2022": true
+      "settings": {
+        "import/resolver": {
+          "typescript": {}
+        }
       }
     },
     {
       "files": ["*.ts"],
-      "parser": "@typescript-eslint/parser",
       "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:@typescript-eslint/strict",
         "plugin:import/recommended",
         "plugin:import/typescript",
         "plugin:prettier/recommended"
       ],
-      "env": {
-        "browser": true,
-        "node": true
-      },
       "parserOptions": {
         "sourceType": "module",
         "project": "tsconfig.json",
@@ -65,9 +66,18 @@
     },
     {
       "files": ["*.json"],
+      "excludedFiles": ["{.eslintrc,tsconfig*}.json"],
       "extends": [
-        "eslint:recommended",
         "plugin:jsonc/recommended-with-json",
+        "plugin:jsonc/prettier",
+        "plugin:prettier/recommended"
+      ]
+    },
+    {
+      // jsonc
+      "files": ["{.eslintrc,tsconfig*}.json"],
+      "extends": [
+        "plugin:jsonc/recommended-with-jsonc",
         "plugin:jsonc/prettier",
         "plugin:prettier/recommended"
       ]

--- a/src/ClockHand.svelte
+++ b/src/ClockHand.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  type $$Props = {
+  import type { SVGAttributes } from 'svelte/elements';
+  interface $$Props extends SVGAttributes<SVGLineElement> {
     length: number;
     limit?: number;
     stationary?: boolean;
-  } & svelte.JSX.SVGProps<SVGLineElement>;
+  }
 
   export let length: number;
   export let limit = 94;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,28 @@
 {
+  // jsonc
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
-    "useDefineForClassFields": true,
     "module": "ESNext",
-    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
     "noEmit": true,
     "baseUrl": "src",
-    "checkJs": true,
-    "isolatedModules": true,
+    "skipLibCheck": true,
     "strict": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "error",
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "importsNotUsedAsValues": "error"
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noPropertyAccessFromIndexSignature": true
   },
-  "include": ["src/**/*.ts", "src/**/*.svelte", "*.config.ts"]
+  "include": ["src/**/*.ts", "*.config.ts"]
 }

--- a/tsconfig.svelte.json
+++ b/tsconfig.svelte.json
@@ -1,0 +1,8 @@
+{
+  // jsonc
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "checkJs": true
+  },
+  "include": ["src/**/*.svelte"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,10 +6,10 @@ import sveltePreprocess from 'svelte-preprocess';
 
 export default ({ mode }: ConfigEnv) =>
   defineConfig({
-    base: loadEnv(mode, process.cwd(), '')['BASE'],
+    base: loadEnv(mode, process.cwd(), '')['BASE'] ?? '',
     plugins: [
       svelte({ preprocess: sveltePreprocess() }),
       uno(),
-      tsconfigPaths(),
+      tsconfigPaths({ projects: ['tsconfig.json', 'tsconfig.svelte.json'] }),
     ],
   });


### PR DESCRIPTION
- stricter TypeScript configuration
- split up configuration for ts and svelte files into two separate configs, to make sure that ESLint works properly
- updated ESLint configuration, cleanup and updated
- updated ClockHand.svelte to remove deprecated svelte.JSX global
- updated vite.config.ts to include both of the new tsconfig files, and also updated it to make it work with new stricter tsconfig