### PR TITLE
fix: vite-tsconfig-paths v4

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "exactOptionalPropertyTypes": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "noPropertyAccessFromIndexSignature": true
+    "noPropertyAccessFromIndexSignature": true,
+    "allowJs": true
   },
   "include": ["src/**/*.ts", "*.config.ts"]
 }


### PR DESCRIPTION
- allowJS must be in the base tsconfig to allow for loading of non TS files