### PR TITLE
Updated ESLint settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,14 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
   },
-  "eslint.validate": ["svelte", "json", "jsonc", "yaml"],
+  "eslint.validate": [
+    "javascript",
+    "typescript",
+    "svelte",
+    "json",
+    "jsonc",
+    "yaml"
+  ],
   "files.associations": {
     "*.css": "tailwindcss"
   }


### PR DESCRIPTION
- all extensions must be added to eslint.validate for the newer versions of extension to work in VSCode